### PR TITLE
python3 compat

### DIFF
--- a/mpl_style_gallery/build.py
+++ b/mpl_style_gallery/build.py
@@ -44,8 +44,8 @@ def save_plots(stylesheet, image_ext=IMAGE_EXT, base_dir=None):
 
         for script in disk.iter_plot_scripts():
             image_name = base_filename(script) + image_ext
-            namespace = {}
-            execfile(script, namespace)
+            with open(script) as f:
+                exec(compile(f.read(), script, 'exec'), {})
             plt.savefig(pth.join(style_dir, image_name))
             plt.close('all')
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,10 @@ install_reqs = list(parse_requirements('requirements.txt'))
 requirements = [str(ir.req) for ir in install_reqs]
 
 info = {}
-execfile(join(package_name, '__init__.py'), info)
+init_py = join(package_name, '__init__.py')
+with open(init_py) as f:
+    code = compile(f.read(), init_py, 'exec')
+    exec(code, info)
 
 
 setup(


### PR DESCRIPTION
python3 doesn’t have `exec`

else kudos for your futureproof style!
